### PR TITLE
Feature ifc primitives

### DIFF
--- a/src/converters/ifcconverter.cpp
+++ b/src/converters/ifcconverter.cpp
@@ -142,6 +142,13 @@ namespace {
         // TODO: Implement
         return 0;
     }
+
+    float getScaleFromTransformation(const Transform3f& transform) {
+        Eigen::Matrix3f rotation;
+        Eigen::Matrix3f scale;
+        transform.computeRotationScaling(&rotation, &scale);
+        return scale(0,0);
+    }
 }
 
 
@@ -307,15 +314,17 @@ void IFCConverter::createPyramid(const std::array<float, 12>& matrix, const Prim
 
 void IFCConverter::createBox(const std::array<float, 12>& matrix, const Primitives::Box& params) {
     if (m_primitives) {
+        Transform3f transform = toEigenTransform(matrix);
+        float s = getScaleFromTransformation(transform);
 
         shared_ptr<IfcPositiveLengthMeasure> xDim (new IfcPositiveLengthMeasure() );
-        xDim->m_value = params.len[0] *  0.001;
+        xDim->m_value = params.len[0] *  s;
 
         shared_ptr<IfcPositiveLengthMeasure> yDim (new IfcPositiveLengthMeasure() );
-        yDim->m_value = params.len[1] *  0.001;
+        yDim->m_value = params.len[1] *  s;
 
         shared_ptr<IfcPositiveLengthMeasure> zDim (new IfcPositiveLengthMeasure() );
-        zDim->m_value = params.len[2] *  0.001;
+        zDim->m_value = params.len[2] * s;
 
         shared_ptr<IfcCartesianPoint> location( new IfcCartesianPoint() );
         insertEntity(location);
@@ -339,7 +348,7 @@ void IFCConverter::createBox(const std::array<float, 12>& matrix, const Primitiv
         direction->m_DirectionRatios.push_back(0);
         direction->m_DirectionRatios.push_back(1);
 
-        Eigen::Vector3f offset(0, 0, -params.len[2] * 0.5f *  0.001f);
+        Eigen::Vector3f offset(0, 0, -params.len[2] * 0.5f *  s);
 
         shared_ptr<IfcExtrudedAreaSolid> box (new IfcExtrudedAreaSolid() );
         insertEntity(box);
@@ -358,10 +367,7 @@ void IFCConverter::createBox(const std::array<float, 12>& matrix, const Primitiv
 void IFCConverter::createRectangularTorus(const std::array<float, 12>& matrix, const Primitives::RectangularTorus& params) {
     if(m_primitives) {
         Transform3f transform = toEigenTransform(matrix);
-        Eigen::Matrix3f rotation;
-        Eigen::Matrix3f scale;
-        transform.computeRotationScaling(&rotation, &scale);
-        const float s = scale.coeff(0,0);
+        const float s = getScaleFromTransformation(transform);
 
         // Define the parametric profile first
         shared_ptr<IfcPositiveLengthMeasure> xDim (new IfcPositiveLengthMeasure() );
@@ -396,10 +402,7 @@ void IFCConverter::createRectangularTorus(const std::array<float, 12>& matrix, c
 void IFCConverter::createCircularTorus(const std::array<float, 12>& matrix, const Primitives::CircularTorus& params) {
     if(m_primitives) {
         Transform3f transform = toEigenTransform(matrix);
-        Eigen::Matrix3f rotation;
-        Eigen::Matrix3f scale;
-        transform.computeRotationScaling(&rotation, &scale);
-        const float s = scale.coeff(0,0);
+        const float s = getScaleFromTransformation(transform);
 
         // Define the parametric profile first
         shared_ptr<IfcPositiveLengthMeasure> radius (new IfcPositiveLengthMeasure() );
@@ -443,16 +446,14 @@ void IFCConverter::createSnout(const std::array<float, 12>& matrix, const Primit
 
 void IFCConverter::createCylinder(const std::array<float, 12>& matrix, const Primitives::Cylinder& params) {
     if (m_primitives) {
-        Transform3f transform = toEigenTransform(matrix);
-        Eigen::Matrix3f rotation;
-        Eigen::Matrix3f scale;
-        transform.computeRotationScaling(&rotation, &scale);
+        const auto transform = toEigenTransform(matrix);
+        const float s = getScaleFromTransformation(transform);
 
         shared_ptr<IfcPositiveLengthMeasure> height (new IfcPositiveLengthMeasure() );
-        height->m_value = params.height()*  scale.coeff(0,0);
+        height->m_value = params.height() * s;
 
         shared_ptr<IfcPositiveLengthMeasure> radius (new IfcPositiveLengthMeasure() );
-        radius->m_value = params.radius()*  scale.coeff(0,0);
+        radius->m_value = params.radius() * s;
 
         shared_ptr<IfcCartesianPoint> location( new IfcCartesianPoint() );
         insertEntity(location);
@@ -475,7 +476,7 @@ void IFCConverter::createCylinder(const std::array<float, 12>& matrix, const Pri
         direction->m_DirectionRatios.push_back(0);
         direction->m_DirectionRatios.push_back(1);
 
-        Eigen::Vector3f offset(0, 0, -params.height() * 0.5f *  scale.coeff(0,0));
+        Eigen::Vector3f offset(0, 0, -params.height() * 0.5f *  s);
 
         shared_ptr<IfcExtrudedAreaSolid> cylinder (new IfcExtrudedAreaSolid() );
         insertEntity(cylinder);

--- a/src/converters/ifcconverter.cpp
+++ b/src/converters/ifcconverter.cpp
@@ -454,7 +454,100 @@ void IFCConverter::createEllipticalDish(const std::array<float, 12>& matrix, con
 }
 
 void IFCConverter::createSphericalDish(const std::array<float, 12>& matrix, const Primitives::SphericalDish& params) {
-    writeMesh(RVMMeshHelper2::makeSphericalDish(params, m_maxSideSize, m_minSides), matrix);
+    if(m_primitives) {
+        Transform3f transform = toEigenTransform(matrix);
+        const float s = getScaleFromTransformation(transform);
+
+        double r = params.diameter() * 0.5 * s;
+        double h = params.height() * s;
+        double offset = r - h;
+        double angle =  asin(1.0 - h / r);
+
+        shared_ptr<IfcPositiveLengthMeasure> radius (new IfcPositiveLengthMeasure() );
+        radius->m_value = r;
+
+        shared_ptr<IfcCartesianPoint> location( new IfcCartesianPoint() );
+        insertEntity(location);
+        location->m_Coordinates.push_back( shared_ptr<IfcLengthMeasure>(new IfcLengthMeasure(0.0) ) );
+        location->m_Coordinates.push_back( shared_ptr<IfcLengthMeasure>(new IfcLengthMeasure(-offset) ) );
+
+        shared_ptr<IfcDirection> direction( new IfcDirection() );
+        insertEntity(direction);
+        direction->m_DirectionRatios.push_back(0);
+        direction->m_DirectionRatios.push_back(1);
+
+        shared_ptr<IfcAxis2Placement2D> position( new IfcAxis2Placement2D() );
+        insertEntity(position);
+        position->m_Location = location;
+        position->m_RefDirection = direction;
+
+        shared_ptr<IfcCircle> circle (new IfcCircle() );
+        insertEntity(circle);
+        circle->m_Radius = radius;
+        circle->m_Position = position;
+
+        shared_ptr<IfcCartesianPoint> p1 (new IfcCartesianPoint() );
+        insertEntity(p1);
+        p1->m_Coordinates.push_back( shared_ptr<IfcLengthMeasure>(new IfcLengthMeasure( r * cos(angle) ) ) );
+        p1->m_Coordinates.push_back( shared_ptr<IfcLengthMeasure>(new IfcLengthMeasure( r * sin(angle) - offset ) ) );
+
+        shared_ptr<IfcCartesianPoint> p2 (new IfcCartesianPoint() );
+        insertEntity(p2);
+        p2->m_Coordinates.push_back( shared_ptr<IfcLengthMeasure>(new IfcLengthMeasure( 0.0 ) ) );
+        p2->m_Coordinates.push_back( shared_ptr<IfcLengthMeasure>(new IfcLengthMeasure( 0.0 ) ) );
+
+        shared_ptr<IfcCartesianPoint> p3 (new IfcCartesianPoint() );
+        insertEntity(p3);
+        p3->m_Coordinates.push_back( shared_ptr<IfcLengthMeasure>(new IfcLengthMeasure( 0.0 ) ) );
+        p3->m_Coordinates.push_back( shared_ptr<IfcLengthMeasure>(new IfcLengthMeasure( h ) ) );
+
+        shared_ptr<IfcPolyline> line (new IfcPolyline() );
+        insertEntity(line);
+        line->m_Points.push_back(p1);
+        line->m_Points.push_back(p2);
+        line->m_Points.push_back(p3);
+
+        shared_ptr<IfcCompositeCurveSegment> segLine (new IfcCompositeCurveSegment() );
+        insertEntity(segLine);
+        segLine->m_Transition = shared_ptr<IfcTransitionCode>(new IfcTransitionCode( IfcTransitionCode::ENUM_CONTINUOUS ));
+        segLine->m_SameSense = true;
+        segLine->m_ParentCurve = line;
+
+        shared_ptr<IfcTrimmedCurve> curve (new IfcTrimmedCurve() );
+        insertEntity(curve);
+        curve->m_BasisCurve = circle;
+        curve->m_Trim1.push_back(p3);
+        curve->m_Trim2.push_back(p1);
+        curve->m_SenseAgreement = false;
+        curve->m_MasterRepresentation = shared_ptr<IfcTrimmingPreference>(new IfcTrimmingPreference( IfcTrimmingPreference::ENUM_CARTESIAN ) );
+
+        shared_ptr<IfcCompositeCurveSegment> segCurve (new IfcCompositeCurveSegment() );
+        insertEntity(segCurve);
+        segCurve->m_Transition = shared_ptr<IfcTransitionCode>(new IfcTransitionCode( IfcTransitionCode::ENUM_CONTINUOUS ));
+        segCurve->m_SameSense = true;
+        segCurve->m_ParentCurve = curve;
+
+        shared_ptr<IfcCompositeCurve> compositeCurve (new IfcCompositeCurve() );
+        insertEntity(compositeCurve);
+        compositeCurve->m_Segments.push_back(segLine);
+        compositeCurve->m_Segments.push_back(segCurve);
+        compositeCurve->m_SelfIntersect = LogicalEnum::LOGICAL_FALSE;
+
+        shared_ptr<IfcArbitraryClosedProfileDef> profile( new IfcArbitraryClosedProfileDef() );
+        insertEntity(profile);
+        profile->m_ProfileType = shared_ptr<IfcProfileTypeEnum>( new IfcProfileTypeEnum( IfcProfileTypeEnum::ENUM_AREA ) );
+        profile->m_OuterCurve = compositeCurve;
+
+        shared_ptr<IfcDirection> axis (new IfcDirection() );
+        insertEntity(axis);
+        axis->m_DirectionRatios.push_back(0);
+        axis->m_DirectionRatios.push_back(1);
+        axis->m_DirectionRatios.push_back(0);
+
+        addRevolvedAreaSolidToShape(profile, axis, 2.0 * M_PI, transform.rotate(Eigen::AngleAxisf(float(0.5*M_PI),  Eigen::Vector3f::UnitX())));
+    } else {
+        writeMesh(RVMMeshHelper2::makeSphericalDish(params, m_maxSideSize, m_minSides), matrix);
+    }
 }
 
 void IFCConverter::createSnout(const std::array<float, 12>& matrix, const Primitives::Snout& params) {

--- a/src/converters/ifcconverter.cpp
+++ b/src/converters/ifcconverter.cpp
@@ -119,15 +119,19 @@ namespace {
         return utf_to_utf<wchar_t>(str.c_str(), str.c_str() + str.size());
     }
 
-    Eigen::Matrix4f toEigenMatrix(const std::array<float, 12>& matrix) {
-        Eigen::Matrix4f result;
+    Transform3f toEigenTransform(const std::array<float, 12>& matrix) {
+        Transform3f result;
         result.setIdentity();
-        for (int i = 0; i < 4; i++) {
-            for (int j = 0; j < 3; j++) {
-                result(j, i)= matrix[i*3+j];
+        for (unsigned int i = 0; i < 3; i++) {
+            for (unsigned int j = 0; j < 4; j++) {
+                result(i, j) = matrix[i+j*3];
             }
         }
         return result;
+    }
+
+    Eigen::Matrix4f toEigenMatrix(const std::array<float, 12>& matrix) {
+        return toEigenTransform(matrix).matrix();
     }
 
     int toTimeStamp(const std::string& schema) {
@@ -326,13 +330,7 @@ void IFCConverter::createSnout(const std::array<float, 12>& matrix, const Primit
 
 void IFCConverter::createCylinder(const std::array<float, 12>& matrix, const Primitives::Cylinder& params) {
     if (m_primitives) {
-        Transform3f transform;
-        transform.setIdentity();
-        for (unsigned int i = 0; i < 3; i++) {
-            for (unsigned int j = 0; j < 4; j++) {
-                transform(i, j) = matrix[i+j*3];
-            }
-        }
+        Transform3f transform = toEigenTransform(matrix);
         Eigen::Matrix3f rotation;
         Eigen::Matrix3f scale;
         transform.computeRotationScaling(&rotation, &scale);

--- a/src/converters/ifcconverter.h
+++ b/src/converters/ifcconverter.h
@@ -46,6 +46,7 @@ class IfcPPEntity;
 class IfcAxis2Placement3D;
 class IfcProfileDef;
 class IfcDirection;
+class IfcPlane;
 
 typedef Eigen::Transform<float, 3, Eigen::Affine> Transform3f;
 
@@ -112,13 +113,16 @@ class IFCConverter : public RVMReader
         shared_ptr<IfcOwnerHistory> createOwnerHistory(const std::string &name, const std::string &banner, int timeStamp);
         shared_ptr<IfcMaterial> createMaterial(int id);
         shared_ptr<IfcSurfaceStyle> createSurfaceStyle(int id);
+        void createSlopedCylinder(const std::array<float, 12>& matrix, const Primitives::Snout& params);
         void insertEntity(shared_ptr<IfcPPEntity> e);
         void initModel();
         void pushParentRelation(shared_ptr<IfcObjectDefinition> parent);
         void addRepresentationToShape(shared_ptr<IfcRepresentationItem> item, shared_ptr<IfcLabel> type);
         void addRevolvedAreaSolidToShape(shared_ptr<IfcProfileDef> profile, shared_ptr<IfcDirection> axis, double angle, const Transform3f& transform);
+
         void writeMesh(const Mesh &mesh, const std::array<float, 12>& matrix);
-        shared_ptr<IfcAxis2Placement3D> getCoordinateSystem(const Transform3f& matrix, const Eigen::Vector3f& offset);
+        shared_ptr<IfcAxis2Placement3D> getCoordinateSystem(const Transform3f& matrix, const Eigen::Vector3f &offset);
+        shared_ptr<IfcPlane> createClippingPlane(double zPos, const Eigen::Vector3d &normal);
 };
 
 #endif // IFCCONVERTER_H

--- a/src/converters/ifcconverter.h
+++ b/src/converters/ifcconverter.h
@@ -45,6 +45,7 @@ class IfcSurfaceStyle;
 class IfcPPEntity;
 class IfcAxis2Placement3D;
 class IfcProfileDef;
+class IfcDirection;
 
 typedef Eigen::Transform<float, 3, Eigen::Affine> Transform3f;
 
@@ -115,7 +116,7 @@ class IFCConverter : public RVMReader
         void initModel();
         void pushParentRelation(shared_ptr<IfcObjectDefinition> parent);
         void addRepresentationToShape(shared_ptr<IfcRepresentationItem> item, shared_ptr<IfcLabel> type);
-        void addRevolvedAreaSolidToShape(shared_ptr<IfcProfileDef> profile, float angle, const Transform3f& transform);
+        void addRevolvedAreaSolidToShape(shared_ptr<IfcProfileDef> profile, shared_ptr<IfcDirection> axis, double angle, const Transform3f& transform);
         void writeMesh(const Mesh &mesh, const std::array<float, 12>& matrix);
         shared_ptr<IfcAxis2Placement3D> getCoordinateSystem(const Transform3f& matrix, const Eigen::Vector3f& offset);
 };

--- a/src/converters/ifcconverter.h
+++ b/src/converters/ifcconverter.h
@@ -28,6 +28,8 @@
 #include <ifcpp/model/IfcPPModel.h>
 #include <ifcpp/model/StatusCallback.h>
 
+#include <Eigen/Core>
+
 #include <stack>
 
 class IfcOwnerHistory;
@@ -41,7 +43,9 @@ class IfcPropertySet;
 class IfcLabel;
 class IfcSurfaceStyle;
 class IfcPPEntity;
+class IfcAxis2Placement3D;
 
+typedef Eigen::Transform<float, 3, Eigen::Affine> Transform3f;
 
 class IFCConverter : public RVMReader
 {
@@ -111,6 +115,7 @@ class IFCConverter : public RVMReader
         void pushParentRelation(shared_ptr<IfcObjectDefinition> parent);
         void addRepresentationToShape(shared_ptr<IfcRepresentationItem> item, shared_ptr<IfcLabel> type);
         void writeMesh(const Mesh &mesh, const std::array<float, 12>& matrix);
+        shared_ptr<IfcAxis2Placement3D> getCoordinateSystem(const Transform3f& matrix, const Eigen::Vector3f& offset);
 };
 
 #endif // IFCCONVERTER_H

--- a/src/converters/ifcconverter.h
+++ b/src/converters/ifcconverter.h
@@ -44,6 +44,7 @@ class IfcLabel;
 class IfcSurfaceStyle;
 class IfcPPEntity;
 class IfcAxis2Placement3D;
+class IfcProfileDef;
 
 typedef Eigen::Transform<float, 3, Eigen::Affine> Transform3f;
 
@@ -114,6 +115,7 @@ class IFCConverter : public RVMReader
         void initModel();
         void pushParentRelation(shared_ptr<IfcObjectDefinition> parent);
         void addRepresentationToShape(shared_ptr<IfcRepresentationItem> item, shared_ptr<IfcLabel> type);
+        void addRevolvedAreaSolidToShape(shared_ptr<IfcProfileDef> profile, float angle, const Transform3f& transform);
         void writeMesh(const Mesh &mesh, const std::array<float, 12>& matrix);
         shared_ptr<IfcAxis2Placement3D> getCoordinateSystem(const Transform3f& matrix, const Eigen::Vector3f& offset);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,7 @@
 using namespace std;
 
 enum optionIndex { UNKNOWN, HELP, TEST,  X3D,
-    X3DB, COLLADA, IFC4, IFC2x3, DSL, DUMMY,
+    X3DB, COLLADA, IFC4, IFC2X3, DSL, DUMMY,
     SKIPATT, SPLIT, AGGREGATE, PRIMITIVES, SIDESIZE,
     MINSIDES, OBJECT, COLOR, SCALE };
 
@@ -58,7 +58,7 @@ const option::Descriptor usage[] = {
     { X3D,          0, "",  "x3d",           option::Arg::None,      "  --x3d  \tConvert to X3D XML format." },
     { X3DB,         0, "",  "x3db",          option::Arg::None,      "  --x3db  \tConvert to X3D binary format." },
     { COLLADA,      0, "",  "collada",       option::Arg::None,      "  --collada\tConvert to COLLADA format." },
-    { IFC2x3,       0, "",  "ifc",           option::Arg::None,      "  --ifc\tConvert to IFC2x3." },
+    { IFC2X3,       0, "",  "ifc",           option::Arg::None,      "  --ifc\tConvert to IFC2x3." },
     { IFC4,         0, "",  "ifc4",          option::Arg::None,      "  --ifc4\tConvert to IFC4." },
     { DSL,          0, "",  "dsl",           option::Arg::None,      "  --dsl  \tConvert to DSL language." },
     { DUMMY,        0, "",  "dummy",         option::Arg::None,      "  --dummy\tPrint out the file structure." },
@@ -126,7 +126,7 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    if ((options[X3D] || options[X3DB] || options[COLLADA] || options[DSL] || options[DUMMY] || options[IFC4]|| options[IFC2x3]) == 0) {
+    if ((options[X3D] || options[X3DB] || options[COLLADA] || options[DSL] || options[DUMMY] || options[IFC4]|| options[IFC2X3]) == 0) {
         cerr << "\nNo format specified.\n";
         option::printUsage(std::cerr, usage);
         return 1;
@@ -215,9 +215,9 @@ int main(int argc, char** argv)
                             reader = new IFCConverter(name, "IFC4");
                         } break;
 
-                        case IFC2x3: {
+                        case IFC2X3: {
                             string name = filename + ".ifc";
-                            reader = new IFCConverter(name, "IFC2x3");
+                            reader = new IFCConverter(name, "IFC2X3");
                         } break;
 
 
@@ -295,13 +295,13 @@ int main(int argc, char** argv)
                         } break;
                         case PYRAMID: {
                             Primitives::Pyramid pyramid;
-                            pyramid.data[0] = 2;
-                            pyramid.data[1] = 4;
-                            pyramid.data[2] = 1;
-                            pyramid.data[3] = 2;
-                            pyramid.data[4] = 2;
-                            pyramid.data[5] = 1;
-                            pyramid.data[6] = 4;
+                            pyramid.data[0] = 2; // xbottom
+                            pyramid.data[1] = 4; // ybottom
+                            pyramid.data[2] = 4; // xtop
+                            pyramid.data[3] = 4; // ytop
+                            pyramid.data[4] = 0; // xoffset
+                            pyramid.data[5] = 0; // yoffset
+                            pyramid.data[6] = 4; // height
 
                             reader->createPyramid(matrix, pyramid);
                         } break;
@@ -359,13 +359,13 @@ int main(int argc, char** argv)
                         reader = new DSLConverter(dslname);
                     } break;
 
-                    case IFC2x3: {
+                    case IFC2X3: {
                         string ifcname = name + ".ifc";
                         reader = new IFCConverter(ifcname, "IFC4");
                     } break;
                     case IFC4: {
                         string ifcname = name + ".ifc";
-                        reader = new IFCConverter(ifcname, "IFC2x3");
+                        reader = new IFCConverter(ifcname, "IFC2X3");
                     } break;
                 }
                 if (maxSideSize) {
@@ -436,11 +436,11 @@ int main(int argc, char** argv)
                             name = name.substr(name.rfind(PATHSEP) + 1);
                             reader = new IFCConverter(name, "IFC4");
                         } break;
-                        case IFC2x3: {
+                        case IFC2X3: {
                             string name = !objectName.empty() ? objectName : filename;
                             name = name.substr(0, name.rfind(".")) + ".ifc";
                             name = name.substr(name.rfind(PATHSEP) + 1);
-                            reader = new IFCConverter(name, "IFC2x3");
+                            reader = new IFCConverter(name, "IFC2X3");
                         } break;
 
                         case DSL: {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -311,7 +311,7 @@ int main(int argc, char** argv)
                         case ELLIPTICALDISH: {
                             Primitives::EllipticalDish dish;
                             dish.data[0] = 4;
-                            dish.data[1] = 4;
+                            dish.data[1] = 2;
                             reader->createEllipticalDish(matrix, dish);
                         } break;
                         case SPHERICALDISH: {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -287,10 +287,10 @@ int main(int argc, char** argv)
                         } break;
                         case RECTANGULARTORUS: {
                             Primitives::RectangularTorus torus;
-                            torus.data[0] = 2;
-                            torus.data[1] = 3;
-                            torus.data[2] = 0.5;
-                            torus.data[3] = (float)M_PI*3/4;
+                            torus.data[0] = 7.5;  // inside
+                            torus.data[1] = 8.0;  // outside
+                            torus.data[2] = 2.0;  // height
+                            torus.data[3] = (float)M_PI*1.5f;
                             reader->createRectangularTorus(matrix, torus);
                         } break;
                         case PYRAMID: {


### PR DESCRIPTION
Using the --primitives option, one can, instead of tessellating RVM primitives, map to extruded/revolved/space clipped versions of the primitives resulting in better preserved semantics, faster processing and smaller file sizes.