### PR TITLE
Corrections made for using PMUC as a shared library in another project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ CMakeList.txt.user*
 /bin
 /bii
 .vscode
-build
+build*

--- a/cmake-lib/CMakeLists.txt
+++ b/cmake-lib/CMakeLists.txt
@@ -1,0 +1,77 @@
+project(PMUC)
+cmake_minimum_required(VERSION 2.8)
+
+# Set C++11 flags to makesome function work
+if(UNIX)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=gnu++0x")
+endif()
+
+set (SRC_LIST
+    ../src/api/rvmcolorhelper.cpp
+    ../src/api/rvmparser.cpp
+    ../src/api/rvmreader.cpp
+    ../src/api/vector3f.cpp
+)
+
+set (HEADER_LIST
+    ../src/api/lib_export.h
+    ../src/api/rvmcolorhelper.h
+    ../src/api/rvmparser.h
+    ../src/api/rvmprimitive.h
+    ../src/api/rvmreader.h
+    ../src/api/vector3f.h
+)
+
+set (USE_MESH_HELPER TRUE CACHE BOOL 
+     "Indicates whether it is needed to include rvmmeshhelper class in the library")
+
+if (USE_MESH_HELPER)
+  # Add OpenGL dependencies
+  set (OpenGL_GL_PREFERENCE LEGACY)
+  find_package (OpenGL REQUIRED)
+
+  list (APPEND SRC_LIST ../src/api/rvmmeshhelper.cpp)
+  list (APPEND HEADER_LIST ../src/api/rvmmeshhelper.h)
+
+endif()
+
+add_library (${PROJECT_NAME} SHARED "${SRC_LIST}")
+
+set_target_properties (${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADER_LIST}")
+
+
+install(TARGETS ${PROJECT_NAME}
+        CONFIGURATIONS Release
+        RUNTIME DESTINATION bin
+        ARCHIVE DESTINATION lib
+	LIBRARY DESTINATION lib
+	PUBLIC_HEADER DESTINATION include/pmuc)
+
+install(TARGETS ${PROJECT_NAME}
+	CONFIGURATIONS Debug
+        RUNTIME DESTINATION bind
+	ARCHIVE DESTINATION libd
+	LIBRARY DESTINATION libd
+        PUBLIC_HEADER DESTINATION include/pmuc)
+
+install(TARGETS ${PROJECT_NAME}
+	CONFIGURATIONS RelWithDebInfo
+        RUNTIME DESTINATION bini
+	ARCHIVE DESTINATION libi
+	LIBRARY DESTINATION libi
+        PUBLIC_HEADER DESTINATION include/pmuc)
+
+if (WIN32)
+  install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}> CONFIGURATIONS Debug
+          DESTINATION bind OPTIONAL)
+  install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}> CONFIGURATIONS RelWithDebInfo
+          DESTINATION bini OPTIONAL)
+endif()
+
+if (USE_MESH_HELPER)
+  # Include OpenGL lib
+  target_link_libraries(${PROJECT_NAME} ${OPENGL_LIBRARIES})
+endif()
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/src/api/lib_export.h
+++ b/src/api/lib_export.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#if defined(_WIN32)
+  #if defined(PMUC_EXPORTS)
+    #define DLL_PMUC_EXPORT __declspec(dllexport)
+  #else  // !BUILDING_DLL
+    #define DLL_PMUC_EXPORT __declspec(dllimport)
+  #endif  // BUILDING_DLL
+#else // / UNIX /
+  #define DLL_PMUC_EXPORT
+#endif // 

--- a/src/api/rvmcolorhelper.h
+++ b/src/api/rvmcolorhelper.h
@@ -22,19 +22,21 @@
 #ifndef RVMCOLORHELPER_H
 #define RVMCOLORHELPER_H
 
+#include "lib_export.h"
+
 #include <vector>
 
 class RVMColorHelper
 {
     public:
-        RVMColorHelper();
+        DLL_PMUC_EXPORT RVMColorHelper();
 
         /**
          * @brief Simple static method to return rgb floats from a PDMS color index. Use the conversion values from Navisworks
          * @param index the PDMS material index
          * @return RGB floats between 0. and 1.
          */
-        static const std::vector<float> color(unsigned char index);
+        DLL_PMUC_EXPORT static const std::vector<float> color(unsigned char index);
 };
 
 #endif // RVMCOLORHELPER_H

--- a/src/api/rvmmeshhelper.h
+++ b/src/api/rvmmeshhelper.h
@@ -29,6 +29,8 @@
 #include "vector3f.h"
 #include "rvmprimitive.h"
 
+#include "lib_export.h"
+
 struct Mesh {
  std::vector<unsigned long>  positionIndex;
  std::vector<unsigned long>  normalIndex;
@@ -54,10 +56,11 @@ enum PrimitiveTypes {
 
 typedef std::pair<Vector3F, Vector3F> Vertex;
 
+
 class RVMMeshHelper2
 {
     public:
-        RVMMeshHelper2();
+        DLL_PMUC_EXPORT RVMMeshHelper2();
 
     public:
         /**
@@ -67,7 +70,7 @@ class RVMMeshHelper2
          * @param minSides not used here. For consistency with the other methods.
          * @return vertexes coordinates and their index.
          */
-        static const Mesh makePyramid(const Primitives::Pyramid& inP, const float& maxSideSize, const int& minSides);
+        DLL_PMUC_EXPORT static const Mesh makePyramid(const Primitives::Pyramid& inP, const float& maxSideSize, const int& minSides);
 
         /**
          * @brief Builds up indexed coordinates for the described box
@@ -78,7 +81,7 @@ class RVMMeshHelper2
          * @param minSides not used here. For consistency with the other methods.
          * @return vertexes coordinates and their index.
          */
-        static const Mesh makeBox(const Primitives::Box& box, const float& maxSideSize, const int& minSides);
+        DLL_PMUC_EXPORT static const Mesh makeBox(const Primitives::Box& box, const float& maxSideSize, const int& minSides);
 
         /**
          * @brief Builds up a sphere with the given radius
@@ -87,7 +90,7 @@ class RVMMeshHelper2
          * @param minSides
          * @return coordinates and normals with their indexes.
          */
-        static const Mesh makeSphere(const Primitives::Sphere &sphere, const float& maxSideSize, const int& minSides);
+        DLL_PMUC_EXPORT static const Mesh makeSphere(const Primitives::Sphere& sphere, const float& maxSideSize, const int& minSides);
 
         /**
          * @brief makeCylinder
@@ -97,7 +100,7 @@ class RVMMeshHelper2
          *
          * @return Returns a mesh object.
          */
-        static const Mesh makeCylinder(const Primitives::Cylinder &cylinder, unsigned long sides);
+        DLL_PMUC_EXPORT static const Mesh makeCylinder(const Primitives::Cylinder& cylinder, unsigned long sides);
 
         /**
          * @brief makeRectangularTorus
@@ -106,7 +109,7 @@ class RVMMeshHelper2
          * @param minSides
          * @return
          */
-        static const Mesh makeRectangularTorus(const Primitives::RectangularTorus& rt, const float& maxSideSize, const int& minSides);
+        DLL_PMUC_EXPORT static const Mesh makeRectangularTorus(const Primitives::RectangularTorus& rt, const float& maxSideSize, const int& minSides);
 
         /**
          * @brief makeCircularTorus
@@ -117,7 +120,7 @@ class RVMMeshHelper2
          * @param minSides
          * @return
          */
-        static const Mesh makeCircularTorus(const Primitives::CircularTorus& cTorus, unsigned long tsides, unsigned long csides);
+        DLL_PMUC_EXPORT static const Mesh makeCircularTorus(const Primitives::CircularTorus& cTorus, unsigned long tsides, unsigned long csides);
 
         /**
          * @brief makeSnout
@@ -130,7 +133,7 @@ class RVMMeshHelper2
          * @param minSides
          * @return
          */
-        static const Mesh makeSnout(const Primitives::Snout& snout, unsigned long sides);
+        DLL_PMUC_EXPORT static const Mesh makeSnout(const Primitives::Snout& snout, unsigned long sides);
 
         /**
          * @brief makeEllipticalDish
@@ -140,7 +143,7 @@ class RVMMeshHelper2
          * @param csides
          * @return
          */
-        static const Mesh makeEllipticalDish(const Primitives::EllipticalDish& eDish, unsigned long sides, unsigned long csides);
+        DLL_PMUC_EXPORT static const Mesh makeEllipticalDish(const Primitives::EllipticalDish& eDish, unsigned long sides, unsigned long csides);
 
         /**
          * @brief makeSphericalDish
@@ -150,10 +153,10 @@ class RVMMeshHelper2
          * @param minSides
          * @return
          */
-        static const Mesh makeSphericalDish(const Primitives::SphericalDish& sDish , const float& maxSideSize, const int& minSides);
+        DLL_PMUC_EXPORT static const Mesh makeSphericalDish(const Primitives::SphericalDish& sDish, const float& maxSideSize, const int& minSides);
 
 
-        static void tesselateFacetGroup(const std::vector<std::vector<std::vector<Vertex> > >& vertices, Mesh* meshData);
+        DLL_PMUC_EXPORT static void tesselateFacetGroup(const std::vector<std::vector<std::vector<Vertex> > >& vertices, Mesh* meshData);
 
         /**
          * @param cylinder The cylinder primitive data.
@@ -163,11 +166,11 @@ class RVMMeshHelper2
          * @return Returns the number of sides of the cylinder.
          */
 
-        static unsigned long infoCylinderNumSides(const Primitives::Cylinder &cylinder, float maxSideSize, unsigned long minSides);
-        static unsigned long infoSnoutNumSides(const Primitives::Snout &snout, float maxSideSize, unsigned long minSides);
+        DLL_PMUC_EXPORT static unsigned long infoCylinderNumSides(const Primitives::Cylinder& cylinder, float maxSideSize, unsigned long minSides);
+        DLL_PMUC_EXPORT static unsigned long infoSnoutNumSides(const Primitives::Snout& snout, float maxSideSize, unsigned long minSides);
 
-        static std::pair<unsigned long, unsigned long> infoCircularTorusNumSides(const Primitives::CircularTorus& cTorus, float maxSideSize, unsigned long minSides);
-        static std::pair<unsigned long, unsigned long> infoEllipticalDishNumSides(const Primitives::EllipticalDish& eDish, float maxSideSize, unsigned long minSides);
+        DLL_PMUC_EXPORT static std::pair<unsigned long, unsigned long> infoCircularTorusNumSides(const Primitives::CircularTorus& cTorus, float maxSideSize, unsigned long minSides);
+        DLL_PMUC_EXPORT static std::pair<unsigned long, unsigned long> infoEllipticalDishNumSides(const Primitives::EllipticalDish& eDish, float maxSideSize, unsigned long minSides);
 };
 
 #endif // RVMMESHHELPER_H

--- a/src/api/rvmparser.cpp
+++ b/src/api/rvmparser.cpp
@@ -680,7 +680,7 @@ bool RVMParser::readGroup(std::istream& is, std::istream* attributeStream)
 
     Vector3F translation;
     readArray_(is, translation.m_values);
-    translation *= 0.001f;
+    translation *= 0.001f * m_scale;
 
     const unsigned int materialId = read_<unsigned int>(is);
 

--- a/src/api/rvmparser.cpp
+++ b/src/api/rvmparser.cpp
@@ -684,9 +684,10 @@ bool RVMParser::readGroup(std::istream& is)
                 size_t i;
                 std::getline(*m_attributeStream, m_currentAttributeLine, '\n');
                 p = trim(latin_to_utf8(m_currentAttributeLine));
-                while ((!m_attributeStream->eof()) && ((i = p.find(":=")) != string::npos)) {
+                std::string separator{":="};
+                while ((!m_attributeStream->eof()) && ((i = p.find(separator)) != string::npos)) {
                      string an = p.substr(0, i);
-                     string av = p.substr(i+4, string::npos);
+                     string av = p.substr(i + separator.size(), string::npos);
 
                      m_reader.startMetaDataPair(an, av);
                      m_reader.endMetaDataPair();

--- a/src/api/rvmparser.cpp
+++ b/src/api/rvmparser.cpp
@@ -447,7 +447,9 @@ RVMParser::RVMParser(RVMReader& reader) :
     m_objectName(""),
     m_objectFound(0),
     m_forcedColor(-1),
+    m_aggregation(false),
     m_scale(1.),
+    m_attributeStream(0),
     m_nbGroups(0),
     m_nbPyramids(0),
     m_nbBoxes(0),
@@ -460,9 +462,7 @@ RVMParser::RVMParser(RVMReader& reader) :
     m_nbSpheres(0),
     m_nbLines(0),
     m_nbFacetGroups(0),
-    m_attributeStream(0),
-    m_attributes(0),
-    m_aggregation(false) {
+    m_attributes(0) {
 }
 
 bool RVMParser::readFile(const string& filename, bool ignoreAttributes)
@@ -654,7 +654,8 @@ const string RVMParser::lastError()
 bool RVMParser::readGroup(std::istream& is)
 {
     skip_<2>(is); // Garbage ?
-    const unsigned int version = read_<unsigned int>(is);
+    //const unsigned int version =
+    read_<unsigned int>(is);
 
     string name;
     read_(is, name);
@@ -729,7 +730,8 @@ bool RVMParser::readGroup(std::istream& is)
 bool RVMParser::readPrimitive(std::istream& is)
 {
     skip_<2>(is); // Garbage ?
-    const unsigned int version = read_<unsigned int>(is);
+    //const unsigned int version =
+    read_<unsigned int>(is);
     const unsigned int primitiveKind = read_<unsigned int>(is);
 
     std::array<float, 12> matrix;
@@ -875,10 +877,11 @@ bool RVMParser::readPrimitive(std::istream& is)
 
 bool RVMParser::readColor(std::istream& is)
 {
-    const auto pos = int(is.tellg());
+    //const auto pos = int(is.tellg());
 
     skip_<2>(is); // Garbage ?
-    const unsigned int version = read_<unsigned int>(is);
+    //const unsigned int version =
+    read_<unsigned int>(is);
     const unsigned int index = read_<unsigned int>(is);
 
     std::array<std::uint8_t, 4> color;

--- a/src/api/rvmparser.h
+++ b/src/api/rvmparser.h
@@ -28,6 +28,7 @@
 #include <array>
 
 #include "vector3f.h"
+#include "lib_export.h"
 
 class RVMReader;
 
@@ -50,7 +51,7 @@ class RVMParser
          * @brief Constructs a parser ready to send data to the provided RVMReader
          * @param reader The reader object that will receive the data.
          */
-        RVMParser(RVMReader& reader);
+        DLL_PMUC_EXPORT RVMParser(RVMReader& reader);
 
         /**
          * @brief Reads from a file a parse its content.
@@ -58,26 +59,26 @@ class RVMParser
          *
          * @return true if the parsing was a success.
          */
-        bool readFile(const std::string& filename, bool ignoreAttributes);
+        DLL_PMUC_EXPORT bool readFile(const std::string& filename, bool ignoreAttributes);
         /**
          * @brief Reads from a series of files.
          * @param filenames a vector of filenames
          *
          * @return true if the parsing was a success.
          */
-        bool readFiles(const std::vector<std::string>& filenames, const std::string& name, bool ignoreAttributes);
+        DLL_PMUC_EXPORT bool readFiles(const std::vector<std::string>& filenames, const std::string& name, bool ignoreAttributes);
         /**
          * @brief Reads from a character buffer.
          * @param buffer the character buffer containing RVM data.
          * @return true if the parsing was a success.
          */
-        bool readBuffer(const char* buffer);
+        DLL_PMUC_EXPORT bool readBuffer(const char* buffer);
         /**
          * @brief Reads RVM data from an input stream
          * @param is the input stream of RVM data.
          * @return true if the parsing was a success.
          */
-        bool readStream(std::istream& is);
+        DLL_PMUC_EXPORT bool readStream(std::istream& is);
 
         /**
          * @brief Allow to filter the RVM data to one named object
@@ -95,7 +96,7 @@ class RVMParser
          * @brief In case of error, returns the last error that occured.
          * @return a string describing the error.
          */
-        const std::string lastError();
+        DLL_PMUC_EXPORT const std::string lastError();
 
         /**
          * @brief Statistics of the parsing: number of groups

--- a/src/api/rvmparser.h
+++ b/src/api/rvmparser.h
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 #include <array>
+#include <map>
+#include <list>
 
 #include "vector3f.h"
 #include "lib_export.h"
@@ -173,6 +175,10 @@ class RVMParser
         bool readGroup(std::istream& is, std::istream* attributeStream);
         bool readPrimitive(std::istream& is);
         bool readColor(std::istream& is);
+        void readArttributes(std::istream& stream);
+        void insertAttributes(const std::string& name, bool ignoreAttributes);
+        bool isFound(const std::string& line, const std::string& substring, size_t& after);
+
 
         void readMatrix(std::istream& is, std::array<float, 12>& matrix);
 
@@ -180,7 +186,6 @@ class RVMParser
         std::string     m_encoding;
         std::string     m_lastError;
 
-        std::string     m_currentAttributeLine;
         std::string     m_objectName;
         int             m_objectFound;
         int             m_forcedColor;
@@ -202,6 +207,11 @@ class RVMParser
         long            m_attributes;
 
         bool            m_brokenByUser;
+
+        using TAttributePair  = std::pair<std::string, std::string>;
+        using TAttributeContainer = std::list<TAttributePair>;
+
+        std::map<std::string, TAttributeContainer> m_groupAttributes;
 };
 
 #endif // RVMPARSER_H

--- a/src/api/rvmparser.h
+++ b/src/api/rvmparser.h
@@ -163,6 +163,11 @@ class RVMParser
          * @return the number of attributes found in the source.
          */
         const long& nbAttributes() { return m_attributes; }
+       
+        /**
+         * @brief Stop reading file/stream by user
+         */
+        DLL_PMUC_EXPORT void Break() { m_brokenByUser = true; }
 
     private:
         bool readGroup(std::istream& is, std::istream* attributeStream);
@@ -195,6 +200,8 @@ class RVMParser
         int             m_nbLines;
         int             m_nbFacetGroups;
         long            m_attributes;
+
+        bool            m_brokenByUser;
 };
 
 #endif // RVMPARSER_H

--- a/src/api/rvmparser.h
+++ b/src/api/rvmparser.h
@@ -78,7 +78,7 @@ class RVMParser
          * @param is the input stream of RVM data.
          * @return true if the parsing was a success.
          */
-        DLL_PMUC_EXPORT bool readStream(std::istream& is);
+        DLL_PMUC_EXPORT bool readStream(std::istream& is, std::istream* attributeStream = NULL);
 
         /**
          * @brief Allow to filter the RVM data to one named object
@@ -165,7 +165,7 @@ class RVMParser
         const long& nbAttributes() { return m_attributes; }
 
     private:
-        bool readGroup(std::istream& is);
+        bool readGroup(std::istream& is, std::istream* attributeStream);
         bool readPrimitive(std::istream& is);
         bool readColor(std::istream& is);
 
@@ -181,7 +181,6 @@ class RVMParser
         int             m_forcedColor;
         bool            m_aggregation;
         float           m_scale;
-        std::istream*   m_attributeStream;
 
         int             m_nbGroups;
         int             m_nbPyramids;

--- a/src/api/rvmreader.cpp
+++ b/src/api/rvmreader.cpp
@@ -22,10 +22,10 @@
 #include "rvmreader.h"
 
 RVMReader::RVMReader() :
-    m_primitives(false),
-    m_split(false),
     m_minSides(16),
-    m_maxSideSize(10) {
+    m_maxSideSize(10),
+    m_split(false),
+    m_primitives(false) {
 }
 
 RVMReader::~RVMReader() {

--- a/src/api/rvmreader.h
+++ b/src/api/rvmreader.h
@@ -26,6 +26,8 @@
 #include <vector>
 #include <array>
 
+#include "lib_export.h"
+
 #include "vector3f.h"
 #include "rvmprimitive.h"
 
@@ -46,11 +48,12 @@ class RVMReader
         /**
          * @brief Default constructor. Initializes variables.
          */
-        RVMReader();
+        DLL_PMUC_EXPORT RVMReader();
+        
         /**
          * @brief Pure virtual destructor
          */
-        virtual ~RVMReader() = 0;
+        DLL_PMUC_EXPORT virtual ~RVMReader();
 
         /**
          * @brief Signals the start of the document.
@@ -217,7 +220,10 @@ class RVMReader
          * @param index - The index of the entry in the color map.
          * @param color - The new color values to be set.
          */
-        virtual void updateColorPalette(std::uint32_t index, const std::array<std::uint8_t, 4> &color) {}
+        virtual void updateColorPalette(std::uint32_t index, const std::array<std::uint8_t, 4>& color) {
+          (void)index;
+          (void)color;
+        }
 
         /**
          * @brief Sets the maximum size for a side of a primitive when tesselating.

--- a/src/api/rvmreader.h
+++ b/src/api/rvmreader.h
@@ -226,6 +226,15 @@ class RVMReader
         }
 
         /**
+         * Set progress of reading rvm file/stream.
+         *
+         * @param progress - The number of read bytes.
+         */
+        DLL_PMUC_EXPORT virtual void updateProgress(std::size_t progress) {
+          (void)progress;
+        }
+
+        /**
          * @brief Sets the maximum size for a side of a primitive when tesselating.
          * @param size
          */

--- a/src/api/vector3f.h
+++ b/src/api/vector3f.h
@@ -22,6 +22,8 @@
 #ifndef Vector3F_H
 #define Vector3F_H
 
+#include "lib_export.h"
+
 #include <vector>
 #include <ostream>
 #include <cmath>
@@ -33,11 +35,11 @@
  */
 class Vector3F
 {
-    public:
-        Vector3F();
-        Vector3F(const float& x, const float& y, const float& z);
-        Vector3F(const Vector3F& v);
-        Vector3F(const std::vector<float>& v);
+public:
+        DLL_PMUC_EXPORT Vector3F();
+        DLL_PMUC_EXPORT Vector3F(const float& x, const float& y, const float& z);
+        DLL_PMUC_EXPORT Vector3F(const Vector3F& v);
+        DLL_PMUC_EXPORT Vector3F(const std::vector<float>& v);
 
         inline float& operator[](int i) {
             return m_values[i];
@@ -78,7 +80,7 @@ class Vector3F
             return 0.f;
         }
 
-        Vector3F cross(const Vector3F& y );
+        DLL_PMUC_EXPORT Vector3F cross(const Vector3F& y);
 
         inline bool equals(const Vector3F& v) const {
             return (m_values[0] == v[0]) && (m_values[1] == v[1]) && (m_values[2] == v[2]);
@@ -89,12 +91,12 @@ class Vector3F
             return *this;
         }
 
-        friend Vector3F operator-(const std::vector<float>& p1, const std::vector<float>& p2);
-        friend Vector3F operator-(const Vector3F& p1, const Vector3F& p2);
-        friend Vector3F operator+(const Vector3F& p1, const Vector3F& p2);
-        friend float operator*(const Vector3F& p1, const Vector3F& p2);
-        friend Vector3F operator*(const Vector3F& v, float f);
-        friend std::ostream& operator<<(std::ostream& out, const Vector3F& vec);
+        DLL_PMUC_EXPORT friend Vector3F operator-(const std::vector<float>& p1, const std::vector<float>& p2);
+        DLL_PMUC_EXPORT friend Vector3F operator-(const Vector3F& p1, const Vector3F& p2);
+        DLL_PMUC_EXPORT friend Vector3F operator+(const Vector3F& p1, const Vector3F& p2);
+        DLL_PMUC_EXPORT friend float operator*(const Vector3F& p1, const Vector3F& p2);
+        DLL_PMUC_EXPORT friend Vector3F operator*(const Vector3F& v, float f);
+        DLL_PMUC_EXPORT friend std::ostream& operator<<(std::ostream& out, const Vector3F& vec);
 
         friend bool operator!=(const Vector3F &a, const Vector3F &b) {
             return !(a==b);


### PR DESCRIPTION
There are several commits in this branch to merge into master.

1. Add possibility to build RVM reader as a separate shared library. Added cmake-lib/CMakeLists.txt to build shared library on Windows and Linux. Removed some warnings.
2. Fix incorrect treatment of the term ':=' in .att file. The patch fixes exception when a key is empty, like "Module:=".
3. Add possibility to read RVM and ATT from streams. It allows for example opening a ZIP archive in memory and performing reading of decoded streams. By the way memory leak through m_attributeStream has been fixed.
4. Support progress indication and user break in RVM reader.
5. Fix for scaling of groups: consider m_scale parameter in translation vector.
6. Fix the bug of skipping attributes for some groups when order in ATT file differs from order in RVM file.